### PR TITLE
Creating  package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "cordova-plugin-fastrde-checkgps",
+  "version": "0.7.2",
+  "description": "https://github.com/AysadKozanoglu/cordova-plugin-fastrde-checkgps.git",
+  "cordova": {
+    "id": "cordova-plugin-fastrde-checkgps",
+    "platforms": [
+      "ios",
+      "android",
+      "browser"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AysadKozanoglu/cordova-plugin-fastrde-checkgps.git"
+  },
+  "keywords": [
+    "appplant",
+    "background",
+    "ecosystem:cordova",
+    "cordova-ios",
+    "cordova-android",
+    "cordova-browser"
+  ],
+  "engines": [
+    {
+      "name": "cordova",
+      "version": ">=3.0.0"
+    },
+    {
+      "name": "android-sdk",
+      "version": ">=16"
+    },
+    {
+      "name": "windows-sdk",
+      "version": ">=10.0.14393.0"
+    }
+  ],
+  "author": "Aysad",
+  "license": "Apache 2.0",
+  "bugs": {
+    "url": "https://github.com/AysadKozanoglu/cordova-plugin-fastrde-checkgps/issues"
+  },
+  "homepage": "https://github.com/AysadKozanoglu/cordova-plugin-fastrde-checkgps#readme"
+}


### PR DESCRIPTION
the command for adding cordova plugin like
```cordova plugin add ..``` needs package.json file to install the plugin. 
Otherwise you will get following error:
```
npm ERR! code ENOPACKAGEJSON
npm ERR! package.json Non-registry package missing package.json: git+https://github.com/fastrde/phonegap-checkGPS.git.
npm ERR! package.json npm can't find a package.json file in your current directory.```
